### PR TITLE
Remove special characters to avoid javac failure

### DIFF
--- a/src/model/Laby.java
+++ b/src/model/Laby.java
@@ -216,13 +216,13 @@ public class Laby extends Observable {
 				break;
 			}
 
-			//Lié avec un patern existant
+			//Lie avec un patern existant
 			if (isOk){
-				//Pareil pour le patern à lier
+				//Pareil pour le patern a lier
 				switch(dessusDessousGaucheDroite(positionPaternACreer, getKey(paternALier))){
-				//créer en bas
+				//creer en bas
 				case 1:
-					//Si celui que j'ai décidé de lié est full mur
+					//Si celui que j'ai decide de lie est full mur
 					if (Patern.estFullMur(face3PaternALier)){
 						paternExistant.remove(paternALier);
 						isOk = false;
@@ -233,7 +233,7 @@ public class Laby extends Observable {
 						}
 					}
 					break;
-					//créer à gauche
+					//creer a gauche
 				case 2:
 					if (Patern.estFullMur(face4PaternALier)){
 						paternExistant.remove(paternALier);
@@ -245,7 +245,7 @@ public class Laby extends Observable {
 						}
 					}
 					break;
-					//créer en haut
+					//creer en haut
 				case 3:
 					if (Patern.estFullMur(face1PaternALier)){
 						paternExistant.remove(paternALier);
@@ -257,7 +257,7 @@ public class Laby extends Observable {
 						}
 					}
 					break;
-					//créer à droite
+					//creer a droite
 				case 4:
 					if (Patern.estFullMur(face2PaternALier)){
 						paternExistant.remove(paternALier);
@@ -281,7 +281,7 @@ public class Laby extends Observable {
 		return potentielPaternAInserer;
 	}
 
-	//position de p2 par rapport à p1
+	//position de p2 par rapport a p1
 	private int dessusDessousGaucheDroite(Point p1, Point p2){
 		if (p2 != null){
 			if (p2.y > p1.y ){
@@ -454,7 +454,7 @@ public class Laby extends Observable {
 		if (!lab.containsKey(p))
 			lab.put(p, patern);
 		else
-			System.err.println("On a set une case qui était déjà set");
+			System.err.println("On a set une case qui etait deja set");
 
 		setChanged();
 		notifyObservers();

--- a/src/model/Perso.java
+++ b/src/model/Perso.java
@@ -13,7 +13,7 @@ public class Perso {
 	private int xCaseDansPatern, yCaseDansPatern;
 	
 	public Perso(double x, double y){
-		//point en haut à gauche
+		//point en haut a gauche
 		this.x=x;
 		this.y=y;
 	}

--- a/src/patern/Patern.java
+++ b/src/patern/Patern.java
@@ -42,7 +42,7 @@ public abstract class Patern {
 				rotation = Rotation.r0;
 				break;
 			case r0:
-				System.err.println("Problème avec la rotation");
+				System.err.println("Probleme avec la rotation");
 				break;
 			}
 		}


### PR DESCRIPTION
Currently compilation fails due to the following errors : 

```
javac src/Main.java 
src/Main.java:1: error: package model does not exist
import model.Laby;
            ^
src/Main.java:2: error: package view does not exist
import view.VueGraphique;
           ^
src/Main.java:3: error: package view does not exist
import view.VueTexte;
           ^
src/Main.java:8: error: cannot find symbol
		Laby lab = new Laby();
		^
  symbol:   class Laby
  location: class Main
src/Main.java:8: error: cannot find symbol
		Laby lab = new Laby();
		               ^
  symbol:   class Laby
  location: class Main
src/Main.java:10: error: cannot find symbol
		VueGraphique vg = new VueGraphique(lab);
		^
  symbol:   class VueGraphique
  location: class Main
src/Main.java:10: error: cannot find symbol
		VueGraphique vg = new VueGraphique(lab);
		                      ^
  symbol:   class VueGraphique
  location: class Main
src/Main.java:11: error: cannot find symbol
		VueTexte vt = new VueTexte(lab);
		^
  symbol:   class VueTexte
  location: class Main
src/Main.java:11: error: cannot find symbol
		VueTexte vt = new VueTexte(lab);
		                  ^
  symbol:   class VueTexte
  location: class Main
9 errors

```

Solution proposed is to remove special characters to replace them with their 'simple' characters counterparts.